### PR TITLE
Corrected pyfusionenergy mod name

### DIFF
--- a/prototypes/bobs-mods/recipes/recipes.lua
+++ b/prototypes/bobs-mods/recipes/recipes.lua
@@ -923,7 +923,7 @@ RECIPE {
     },
 }:add_unlock("advanced-electronics")
 
-if mods["pyfusion"] then
+if mods["pyfusionenergy"] then
 
 RECIPE {
     type = "recipe",


### PR DESCRIPTION
Incorrect mod name leads to missing recipes connected to it.